### PR TITLE
Teste/ivan lempek

### DIFF
--- a/TheatricalPlayersRefactoringKata.Tests/StatementPrinterTests.cs
+++ b/TheatricalPlayersRefactoringKata.Tests/StatementPrinterTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/TheatricalPlayersRefactoringKata.Tests/StatementPrinterTests.cs
+++ b/TheatricalPlayersRefactoringKata.Tests/StatementPrinterTests.cs
@@ -1,16 +1,20 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using ApprovalTests;
-using ApprovalTests.Approvers;
 using ApprovalTests.Namers;
 using ApprovalTests.Reporters;
-using TheatricalPlayersRefactoringKata.Application.DTOs;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using TheatricalPlayersRefactoringKata.Application.UseCases;
 using TheatricalPlayersRefactoringKata.Domain.Entities;
 using TheatricalPlayersRefactoringKata.Domain.Interfaces;
 using TheatricalPlayersRefactoringKata.Domain.Services.FormatterSelection;
+using TheatricalPlayersRefactoringKata.Infrastructure.Queues;
 using TheatricalPlayersRefactoringKata.Infrastructure.Repositories;
+using TheatricalPlayersRefactoringKata.Infrastructure.Services;
 using TheatricalPlayersRefactoringKata.Presentation;
 using Xunit;
 
@@ -171,4 +175,62 @@ public class StatementPrinterTests
 
         Approvals.Verify(result);
     }
+
+    [Fact]
+    public async Task TestAsynchronousStatementProcessing()
+    {
+        var plays = new Dictionary<string, Play>
+        {
+            { "hamlet", new Play("Hamlet", 4024, "tragedy") },
+            { "as-like", new Play("As You Like It", 2670, "comedy") },
+            { "othello", new Play("Othello", 3560, "tragedy") },
+        };
+
+        var invoice1 = new Invoice(
+            "TestCustomer1",
+            new List<Performance>
+            {
+                new Performance("hamlet", 55),
+                new Performance("as-like", 35),
+                new Performance("othello", 40),
+            }
+        );
+
+        var invoice2 = new Invoice(
+            "TestCustomer2",
+            new List<Performance>
+            {
+                new Performance("othello", 40),
+                new Performance("hamlet", 60)
+            }
+        );
+
+        IPlayRepository playRepository = new PlayRepository(plays);
+        var generateStatementUseCase = new GenerateStatementUseCase(playRepository);
+        var xmlFormatter = new XmlStatementPrinter();
+
+        // Create the statement queue and enqueue the invoices
+        IStatementQueue statementQueue = new StatementQueue();
+        statementQueue.EnqueueStatement(invoice1);
+        statementQueue.EnqueueStatement(invoice2);
+
+        ILogger<StatementProcessingService> logger = NullLogger<StatementProcessingService>.Instance;
+
+        var statementProcessingService = new StatementProcessingService(
+            statementQueue,
+            generateStatementUseCase,
+            xmlFormatter,
+            logger
+        );
+
+        var cts = new CancellationTokenSource();
+
+        // Start the service
+        await statementProcessingService.StartAsync(cts.Token);
+
+        await Task.Delay(TimeSpan.FromSeconds(5));
+
+        // Stop the service
+        await statementProcessingService.StopAsync(cts.Token);
+    } 
 }

--- a/TheatricalPlayersRefactoringKata.Tests/TheatricalPlayersRefactoringKata.Tests.csproj
+++ b/TheatricalPlayersRefactoringKata.Tests/TheatricalPlayersRefactoringKata.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="5.7.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/TheatricalPlayersRefactoringKata/Application/UseCases/EnqueueStatementUseCase.cs
+++ b/TheatricalPlayersRefactoringKata/Application/UseCases/EnqueueStatementUseCase.cs
@@ -1,0 +1,19 @@
+﻿using TheatricalPlayersRefactoringKata.Domain.Entities;
+using TheatricalPlayersRefactoringKata.Domain.Interfaces;
+
+namespace TheatricalPlayersRefactoringKata.Application.UseCases;
+
+public class EnqueueStatementUseCase
+{
+    private readonly IStatementQueue _statementQueue;
+
+    public EnqueueStatementUseCase(IStatementQueue statementQueue)
+    {
+        _statementQueue = statementQueue;
+    }
+
+    public void Execute(Invoice invoice)
+    {
+        _statementQueue.EnqueueStatement(invoice);
+    }
+}

--- a/TheatricalPlayersRefactoringKata/Domain/Interfaces/IStatementQueue.cs
+++ b/TheatricalPlayersRefactoringKata/Domain/Interfaces/IStatementQueue.cs
@@ -1,0 +1,9 @@
+﻿using TheatricalPlayersRefactoringKata.Domain.Entities;
+
+namespace TheatricalPlayersRefactoringKata.Domain.Interfaces;
+
+public interface IStatementQueue
+{
+    void EnqueueStatement(Invoice invoice);
+    bool TryDequeueStatement(out Invoice invoice);
+}

--- a/TheatricalPlayersRefactoringKata/Infrastructure/Queues/StatementQueue.cs
+++ b/TheatricalPlayersRefactoringKata/Infrastructure/Queues/StatementQueue.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Concurrent;
+using TheatricalPlayersRefactoringKata.Domain.Entities;
+using TheatricalPlayersRefactoringKata.Domain.Interfaces;
+
+namespace TheatricalPlayersRefactoringKata.Infrastructure.Queues;
+
+public class StatementQueue : IStatementQueue
+{
+    private readonly ConcurrentQueue<Invoice> _queue = new ConcurrentQueue<Invoice>();
+
+    public void EnqueueStatement(Invoice invoice)
+    {
+        _queue.Enqueue(invoice);
+    }
+
+    public bool TryDequeueStatement(out Invoice invoice)
+    {
+        return _queue.TryDequeue(out invoice);
+    }
+}

--- a/TheatricalPlayersRefactoringKata/Infrastructure/Services/StatementProcessingService.cs
+++ b/TheatricalPlayersRefactoringKata/Infrastructure/Services/StatementProcessingService.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.IO;
+using TheatricalPlayersRefactoringKata.Application.UseCases;
+using TheatricalPlayersRefactoringKata.Domain.Entities;
+using TheatricalPlayersRefactoringKata.Domain.Interfaces;
+using TheatricalPlayersRefactoringKata.Presentation;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
+
+namespace TheatricalPlayersRefactoringKata.Infrastructure.Services;
+
+public class StatementProcessingService : BackgroundService
+{
+    private readonly IStatementQueue _statementQueue;
+    private readonly GenerateStatementUseCase _generateStatementUseCase;
+    private readonly XmlStatementPrinter _xmlFormatter;
+    private readonly ILogger<StatementProcessingService> _logger;
+
+    public StatementProcessingService(
+        IStatementQueue statementQueue,
+        GenerateStatementUseCase generateStatementUseCase,
+        XmlStatementPrinter xmlFormatter,
+        ILogger<StatementProcessingService> logger)
+    {
+        _statementQueue = statementQueue;
+        _generateStatementUseCase = generateStatementUseCase;
+        _xmlFormatter = xmlFormatter;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Statement Processing Service is starting.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (_statementQueue.TryDequeueStatement(out var invoice))
+                {
+                    // Process the invoice
+                    var statementResult = _generateStatementUseCase.GenerateExtractValues(invoice);
+                    string xmlOutput = _xmlFormatter.Print(statementResult);
+
+                    // Save XML to directory
+                    SaveXmlToFile(invoice, xmlOutput);
+
+                    _logger.LogInformation($"Processed invoice for {invoice.Customer}.");
+                }
+                else
+                {
+                    // No items in queue, wait for a short period
+                    await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while processing statements.");
+            }
+        }
+
+        _logger.LogInformation("Statement Processing Service is stopping.");
+    }
+
+    private void SaveXmlToFile(Invoice invoice, string xmlContent)
+    {
+        // Create the directory in TheatricalPlayersRefactoringKata.Tests\bin\Debug\net6.0\ProcessedStatements
+        string directoryPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ProcessedStatements");
+        Directory.CreateDirectory(directoryPath);
+
+        string fileName = $"Statement_{invoice.Customer}_{DateTime.Now:yyyyMMddHHmmss}.xml";
+        string filePath = Path.Combine(directoryPath, fileName);
+
+        File.WriteAllText(filePath, xmlContent);
+    }
+}

--- a/TheatricalPlayersRefactoringKata/TheatricalPlayersRefactoringKata.csproj
+++ b/TheatricalPlayersRefactoringKata/TheatricalPlayersRefactoringKata.csproj
@@ -4,4 +4,9 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- Adicionado novas camadas para a execução de filas. Adicionado serviço do qual implementa o processamento de fila de impressões de XML. Após a impressão ser gerada ele salva o XML na pasta ProcessedStatements.
-  Adicionado teste para processar duas impressões com filas e de forma assíncrona.
